### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides a secure JavaScript execution environment.
 
+<a href="https://glama.ai/mcp/servers/agatnhlgki">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/agatnhlgki/badge" alt="JavaScript Sandbox Server MCP server" />
+</a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [JavaScript Sandbox MCP Server](https://glama.ai/mcp/servers/agatnhlgki) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/agatnhlgki">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/agatnhlgki/badge" alt="JavaScript Sandbox Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.